### PR TITLE
Install AMM onto a different profile than R2Northstar

### DIFF
--- a/AutoMatchmakingMod_Installer.bat
+++ b/AutoMatchmakingMod_Installer.bat
@@ -11,11 +11,11 @@ rmdir /s /q "R2Northstar/plugins/DiscordRPC.dll"
 rmdir /s /q "R2Northstar/mods/Northstar.Client"
 rmdir /s /q "R2Northstar/mods/Northstar.Custom"
 rmdir /s /q "R2Northstar/mods/Northstar.CustomServers"
-mkdir "R2Northstar/mods/TimeIsUnending.AutoMatchmaking.1.0.4"
-cd R2Northstar/mods/TimeIsUnending.AutoMatchmaking.1.0.4
+mkdir "R2Vanilla/mods/TimeIsUnending.AutoMatchmaking.1.0.4"
+cd R2Vanilla/mods/TimeIsUnending.AutoMatchmaking.1.0.4
 curl -LO https://github.com/TimeIsUnending/TF2-Auto-Matchmaking-Mod/releases/download/v1.0.4/TimeIsUnending.AutoMatchmaking.1.0.4.zip
 tar -xf TimeIsUnending.AutoMatchmaking.1.0.4.zip
 del TimeIsUnending.AutoMatchmaking.1.0.4.zip
 cd ../../..
-echo -multiple -norestrictservercommands +ns_has_agreed_to_send_token 2 > ns_startup_args.txt
+echo -multiple -norestrictservercommands -profile="R2Vanilla" +ns_has_agreed_to_send_token 2 > ns_startup_args.txt
 del Northstar.release.v1.11.1.zip


### PR DESCRIPTION
Preserves people's northstar installs if installed with northstar already installed, also allows people to install separate mods for vanilla (AMM) and northstar