### PR TITLE
Stop auto matchmaking when player disconnected from match

### DIFF
--- a/TimeIsUnending.AutoMatchmaking.1.0.5/mod.json
+++ b/TimeIsUnending.AutoMatchmaking.1.0.5/mod.json
@@ -20,6 +20,14 @@
             "ClientCallback": {
                 "After": "AM_Init"
             }
+        },
+        {
+            "Path": "client/cl_automatchmaking.nut",
+            "RunOn": "CLIENT",
+            "ClientCallback":
+            {
+                "Before": "AM_Client_Init"
+            }
         }
     ]
 }

--- a/TimeIsUnending.AutoMatchmaking.1.0.5/mod/scripts/vscripts/client/cl_automatchmaking.nut
+++ b/TimeIsUnending.AutoMatchmaking.1.0.5/mod/scripts/vscripts/client/cl_automatchmaking.nut
@@ -1,0 +1,11 @@
+global function AM_Client_Init
+
+void function AM_Client_Init() {
+    AddCallback_GameStateEnter( eGameState.Playing, AM_OnEnterGame )
+}
+
+void function AM_OnEnterGame()
+{
+    // Stop auto matchmaking when entering a match
+    SetConVarInt( "am_matchmaking", 0 )
+}

--- a/TimeIsUnending.AutoMatchmaking.1.0.5/mod/scripts/vscripts/client/cl_automatchmaking.nut
+++ b/TimeIsUnending.AutoMatchmaking.1.0.5/mod/scripts/vscripts/client/cl_automatchmaking.nut
@@ -2,6 +2,7 @@ global function AM_Client_Init
 
 void function AM_Client_Init() {
     AddCallback_GameStateEnter( eGameState.Playing, AM_OnEnterGame )
+    AddCallback_GameStateEnter( eGameState.PickLoadout, AM_OnEnterGame )
 }
 
 void function AM_OnEnterGame()


### PR DESCRIPTION
Stop auto matchmaking when reconnects to lobby after disconnecting from an ongoing match. The idea is to set `am_matchmaking` to 0 when entering match to indicate that the game is not matchmaking anymore.